### PR TITLE
FDK-1215 openApiSpec 3.0 example file

### DIFF
--- a/examples/openApiSpec3/enhetsregisteretOpneData-openApi3.json
+++ b/examples/openApiSpec3/enhetsregisteretOpneData-openApi3.json
@@ -1,0 +1,136 @@
+{
+	"openapi": "3.0.1",
+	"info": {
+		"description": "Tilbyr et utvalg av opplysninger om alle registrerte enheter i Enhetsregisteret",
+		"version": "0.1",
+		"title": "Åpne data - Enhetsregisteret",
+		"termsOfService": "https://fellesdatakatalog.brreg.no/about",
+		"contact": {
+			"name": "Brønnøysundregistrene",
+			"url": "http://www.brreg.no",
+			"email": "opendata@brreg.no"
+		},
+		"license": {
+			"name": "Norsk lisens for offentlige data (NLOD) 2.0",
+			"url": "http://data.norge.no/nlod/no/2.0"
+		}
+	},
+	"servers": [
+		{
+			"url": "https://data.brreg.no/enhetsregisteret/api",
+			"description": "Produksjonsserver"
+		}
+	],
+	"paths": {
+		"/": {
+			"get": {
+				"description": "Rot. lister lenker til øvrige objekter",
+				"responses": {
+					"200": {          
+						"description": "En liste med lenker til øvrige tjenester"
+					}
+				}
+			}
+		},
+		"/enheter": {
+			"get": {
+				"description": "Søk etter enheter",
+				"responses": {
+					"200": {          
+						"description": "En liste med enheter"
+					}
+				}
+			}
+		},
+		"/enheter/{orgnr}": {
+			"get": {
+				"description": "Hent en spesifikk enhet",
+				"responses": {
+					"200": {          
+						"description": "En enhet"
+					}
+				}
+			}
+		},
+		"/enheter/lastned": {
+			"get": {
+				"description": "Last ned enheter",
+				"responses": {
+					"200": {          
+						"description": "Zip-fil lastes ned"
+					}
+				}
+			}
+		},
+		"/underenheter": {
+			"get": {
+				"description": "Søk etter underenheter",
+				"responses": {
+					"200": {          
+						"description": "En liste med underenheter"
+					}
+				}
+			}
+		},
+		"/underenheter/{orgnr}": {
+			"get": {
+				"description": "Hent en spesifikk underenhet",
+				"responses": {
+					"200": {          
+						"description": "En underenhete"
+					}
+				}
+			}
+		},
+		"/underenheter/lastned": {
+			"get": {
+				"description": "Last ned underenheter",
+				"responses": {
+					"200": {          
+						"description": "En liste med underenheter"
+					}
+				}
+			}
+		},
+		"/organisasjonsformer": {
+			"get": {
+				"description": "Hent alle organisasjonsformer",
+				"responses": {
+					"200": {          
+						"description": "En liste med organisasjonsformer"
+					}
+				}
+			}
+		},
+		"/organisasjonsformer/enheter": {
+			"get": {
+				"description": "Hent alle organisasjonsformer for enheter",
+				"responses": {
+					"200": {          
+						"description": "En liste med organisasjonsformer"
+					}
+				}
+			}
+		},
+		"/organisasjonsformer/underenheter": {
+			"get": {
+				"description": "Hent alle organisasjonsformer for underenheter",
+				"responses": {
+					"200": {          
+						"description": "En liste med organisasjonsformer"
+					}
+				}
+			}
+		},
+		"/organisasjonsformer/{orgkode}": {
+			"get": {
+				"description": "Hent en gitt organisasjonsform",
+				"responses": {
+					"200": {          
+						"description": "Beskrivelse av organisasjonsform"
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Ekesempelfil for Åpne data enhetsregisteret tjeneste.
Dekker kun felter som er med i designskisse:
 Covers only fields in design sketch at https://69d4ft.axshare.com/#g=1&p=detaljside

Se beskrivelse:
https://confluence.brreg.no/pages/viewpage.action?pageId=99265781